### PR TITLE
Feature/yihua/disable input on send

### DIFF
--- a/app/(conversation)/page.jsx
+++ b/app/(conversation)/page.jsx
@@ -9,6 +9,7 @@ export default function HomePage() {
   const router = useRouter();
   const [userMessage, setUserMessage] = useState("");
   const [userUid, setUserUid] = useState(null);
+  const [isSending, setIsSending] = useState(false);
 
   // 在元件載入時從 localStorage 抓取 user_uid
   useEffect(() => {
@@ -20,6 +21,8 @@ export default function HomePage() {
 
   // 當使用者輸入訊息後
   const handleSend = async () => {
+    if (isSending) return;
+
     try {
       // 確認有取得 userUid 才進行 API 呼叫
       if (!userUid) {
@@ -31,6 +34,8 @@ export default function HomePage() {
         alert("請先輸入訊息");
         return;
       }
+
+      setIsSending(true);
 
       // 1. 呼叫後端 API 建立新的對話
       const data = await createConversation(userUid);
@@ -91,12 +96,13 @@ export default function HomePage() {
             focus-visible:outline-none
           "
           onKeyDown={handleKeyDown}
+          disabled={isSending}
         />
 
         <div className="flex justify-end">
           <Button
             onClick={handleSend}
-            disabled={!userMessage.trim()}
+            disabled={!userMessage.trim() || isSending}
             className="
               rounded-xl
               px-3

--- a/app/service/conversation/InternalService/messageDecorator.jsx
+++ b/app/service/conversation/InternalService/messageDecorator.jsx
@@ -15,8 +15,8 @@ const ROLE_MAPPING = {
 export function inboundMessageDecorator(rawData) {
   try {
     const data = JSON.parse(rawData);
-    const { text_content, role } = data;
-    return { role, text_content: text_content };
+    const { text_content, role, event_type } = data;
+    return { event_type, role, text_content: text_content };
   } catch (err) {
     console.error("[inboundMessageDecorator] parse error:", err, rawData);
     return null;

--- a/components/conversation/ConversationClient.jsx
+++ b/components/conversation/ConversationClient.jsx
@@ -24,10 +24,8 @@ export default function ConversationClient({ conversationId }) {
     chatMessages,
     typingMessage,
     handleSendMessage,
+    isSending,
   } = useConversation(conversationId);
-
-  // 只要 typingMessage.content 有字就鎖定輸入
-  const isInputDisabled = Boolean(typingMessage?.content?.trim());
 
   function handleOptionSelect(label) {
     setInputValue((prev) => (prev ? prev + " " + label : label));
@@ -63,7 +61,7 @@ export default function ConversationClient({ conversationId }) {
             onChange={setInputValue}
             onSend={handleSendMessage}
             isLoading={isLoading}
-            isDisabled={isInputDisabled}
+            isSending={isSending}
             conversationId={conversationId}
           />
         </div>

--- a/components/conversation/ConversationInput.jsx
+++ b/components/conversation/ConversationInput.jsx
@@ -8,38 +8,38 @@ export function ConversationInput({
   onChange,
   onSend,
   isLoading,
-  isDisabled = false, // true = 仍可打字，但禁止送出
+  isSending = false, // true = 仍可打字，但禁止送出
 }) {
   return (
     <div className="w-auto mx-auto py-4 flex flex-col gap-2 rounded-2xl border border-border bg-muted">
-      {/* 多行輸入框 —— 不再 disabled */}
+      {/* 上半部：多行輸入框 —— 修改 disabled 屬性 */}
       <textarea
         value={inputValue}
         onChange={(e) => onChange(e.target.value)}
-        placeholder={isDisabled ? "Assistant 正在輸出中…" : "Type message..."}
+        placeholder={isSending ? "Assistant 正在輸出中…" : "Type message..."}
         className="
           flex-1 bg-muted px-3 py-2 text-sm leading-6
           resize-y overflow-auto focus-visible:outline-none
         "
+        // 只要 isSending，就完全禁止 Enter 送出；但可繼續打字與 Shift+Enter 換行
         onKeyDown={(e) => {
-          // 只要 isDisabled，就完全禁止 Enter 送出；但可繼續打字與 Shift+Enter 換行
           if (e.key === "Enter" && !e.shiftKey) {
             e.preventDefault();
-            if (!isDisabled && inputValue.trim() !== "") {
+            if (!isSending && inputValue.trim() !== "") {
               onSend(inputValue);
             }
           }
         }}
       />
 
-      {/* 送出按鈕 —— 仍照 isDisabled 鎖住 */}
+      {/* 下半部：送出按鈕 —— 仍照 isSending 鎖住 */}
       <div className="flex justify-end">
         <Button
           onClick={() => {
-            if (isDisabled || inputValue.trim() === "") return;
+            if (isSending || inputValue.trim() === "") return;
             onSend(inputValue);
           }}
-          disabled={isLoading || !inputValue.trim() || isDisabled}
+          disabled={isLoading || !inputValue.trim() || isSending}
           className="rounded-xl px-3 py-2 h-fit mt-2 mr-2"
         >
           {isLoading ? "Sending..." : "→"}

--- a/components/test/TestClient.tsx
+++ b/components/test/TestClient.tsx
@@ -42,6 +42,7 @@ export default function TestClient({
     chatMessages,
     typingMessage,
     handleSendMessage,
+    isSending,
   } = useConversation(conversationUid, initialMessages, defaultUserInput);
 
   //按下option後讓文字進到使用者輸入框
@@ -68,6 +69,7 @@ export default function TestClient({
         onChange={setInputValue}
         onSend={handleSendMessage}
         isLoading={isLoading}
+        isSending={isSending}
       />
     </div>
   );

--- a/components/test/TestInput.tsx
+++ b/components/test/TestInput.tsx
@@ -8,50 +8,42 @@ import { Button } from "@/components/ui/button";
  * - inputValue: 當前輸入框的值
  * - onChange: 更新父層 state
  * - onSend: 送出訊息動作
- * - isLoading: 是否正在送出中
+ * - isLoading: 是否正在載入歷史對話
+ * - isSending: 是否正在生成回覆
  */
 
-export default function TestInput({ inputValue, onChange, onSend, isLoading }) {
+export default function TestInput({ inputValue, onChange, onSend, isLoading, isSending }) {
   return (
     <div className="w-1/2 mx-auto py-4 flex flex-col gap-2 rounded-2xl border border-border bg-muted">
-      {/* 上半部：多行輸入框 */}
+      {/* 上半部：多行輸入框 —— 修改 disabled 屬性 */}
       <textarea
         value={inputValue}
         onChange={(e) => onChange(e.target.value)}
-        placeholder="Type message..."
+        placeholder={isSending ? "Assistant 正在輸出中…" : "Type message..."}
         className="
-          flex-1
-          bg-muted
-          px-3
-          py-2
-          text-sm
-          leading-6
-          resize-y
-          overflow-auto
-          focus-visible:outline-none
+          flex-1 bg-muted px-3 py-2 text-sm leading-6
+          resize-y overflow-auto focus-visible:outline-none
         "
-        // 按 Enter 送出，Shift+Enter 換行
+        // 只要 isDisabled，就完全禁止 Enter 送出；但可繼續打字與 Shift+Enter 換行
         onKeyDown={(e) => {
           if (e.key === "Enter" && !e.shiftKey) {
             e.preventDefault();
-            onSend();
+            if (!isSending && inputValue.trim() !== "") {
+              onSend(inputValue);
+            }
           }
         }}
       />
 
-      {/* 下半部：右側箭頭按鈕 */}
+      {/* 下半部：送出按鈕 —— 仍照 isSending 鎖住 */}
       <div className="flex justify-end">
         <Button
-          onClick={onSend}
-          disabled={isLoading}
-          className="
-            rounded-xl
-            px-3
-            py-2
-            h-fit
-            mt-2
-            mr-2
-          "
+          onClick={() => {
+            if (isSending || inputValue.trim() === "") return;
+            onSend(inputValue);
+          }}
+          disabled={isLoading || !inputValue.trim() || isSending}
+          className="rounded-xl px-3 py-2 h-fit mt-2 mr-2"
         >
           {isLoading ? "Sending..." : "→"}
         </Button>


### PR DESCRIPTION
## 🚀 目的 / Motivation

- 修正「傳送文本時連續按enter會送多次訊息」問題
- 新增 `event_type` 從 websocket recieve 判斷送出按鈕狀態


## 📝 主要變更 / What’s Changed

- websocket recieve：
  - 新增 `event_type` 用於判斷是否為串流訊息中、結束或其他狀態
  ```
	{
	  "event_type": <string>, // 1, 2, 3
	  "conversation_uid": <uuid>,
	  "text_content": [
		{
		  "type": <string>,
		  "content": <string>
		}
	  ]
	}
  ```

- 統一 `isSending` 控制送出按鈕狀態：
  - 替換 `isDisabled` 成 `isSending`
  - 確保送出按鈕僅依賴 isSending 控制啟用 / 禁用
  - 完善送出按鈕在訊息送出前、串流中與結束後的生命週期


## 📜 測試項目 / Test Case

- [ ] 送出訊息後瘋狂按enter，確保訊息不會被送出
- [ ] 收到「結束訊息」後，才能正常送出訊息


## 📷 螢幕截圖 / Demo
<img width="1913" height="930" alt="image" src="https://github.com/user-attachments/assets/0b63709e-b49d-43ac-8317-f55dd19ed883" />